### PR TITLE
Implement cleanup step for Bunny CDN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,4 +35,37 @@ jobs:
               --fail || { echo "❌ Failed uploading $file" ; exit 1; }
           done
 
+      - name: Delete removed files from Bunny CDN Storage
+        run: |
+          set -e
+          ACCESS_KEY="${{ secrets.BUNNY_STORAGE_PASSWORD }}"
+          ZONE="gundelsby-com-webpage"
+
+          find _site -type f -printf '%P\n' | sort > local-files.txt
+
+          list_remote() {
+            local path="$1"
+            curl -s -H "AccessKey: $ACCESS_KEY" "https://storage.bunnycdn.com/$ZONE/$path" |
+              jq -r '.[] | [.ObjectName, .IsDirectory] | @tsv' |
+              while IFS=$'\t' read name isdir; do
+                if [ "$isdir" = "true" ]; then
+                  list_remote "$path$name/"
+                else
+                  echo "$path$name"
+                fi
+              done
+          }
+
+          list_remote "" | sort > remote-files.txt
+          comm -23 remote-files.txt local-files.txt > to-delete.txt
+
+          while read file; do
+            [ -z "$file" ] && continue
+            echo "Deleting: $file"
+            curl -X DELETE -s \
+              -H "AccessKey: $ACCESS_KEY" \
+              "https://storage.bunnycdn.com/$ZONE/$file" \
+              --fail || { echo "❌ Failed deleting $file" ; exit 1; }
+          done < to-delete.txt
+
   


### PR DESCRIPTION
## Summary
- add step to delete remote files from Bunny CDN that aren't present in the `_site` build

## Testing
- `git status --short`