### PR TITLE
Add schema.org Person metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains the source for Jan Henrik's personal website. The site is built with [Jekyll](https://jekyllrb.com/) using the [cvless](https://github.com/piazzai/cvless) theme.
 
+The site exposes [schema.org](https://schema.org) `Person` metadata to help search engines and chatbots better understand its content.
+
 ## Local development with Docker
 
 1. Ensure [Docker](https://docs.docker.com/get-docker/) and [docker-compose](https://docs.docker.com/compose/install/) are installed.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,4 +21,5 @@
   <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ 'atom.xml' | relative_url }}">
 
   {% seo title=false %}
+  {% include schema-person.html %}
 </head>

--- a/_includes/schema-person.html
+++ b/_includes/schema-person.html
@@ -1,0 +1,12 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "{{ site.author.name | escape }}",
+  "url": "{{ site.url | absolute_url }}",
+  "image": "{{ site.photo | relative_url | absolute_url }}",
+  "sameAs": [
+    {% if site.social.github %}"https://github.com/{{ site.social.github }}"{% endif %}{% if site.social.linkedin %},{% if site.social.github %} {% endif %}"https://www.linkedin.com/in/{{ site.social.linkedin }}"{% endif %}
+  ]
+}
+</script>


### PR DESCRIPTION
## Summary
- embed schema.org `Person` JSON-LD metadata to aid chatbots and search engines
- document structured data support in README

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_6894ac0331348320b4b5f827291377c5